### PR TITLE
Revamp images

### DIFF
--- a/assets/scss/_transitions.scss
+++ b/assets/scss/_transitions.scss
@@ -18,14 +18,4 @@
   overflow:hidden;
   background:$white;
 }
-.opti-image{
-  transition: 0.2s ease opacity, 0.2s ease filter;
-  opacity:1;
-  filter: blur(0);
-}
-
-.opti-image-before-load{
-  opacity:0;
-  filter: blur(10px);
-}
 /* purgecss end ignore */

--- a/components/Markdown.vue
+++ b/components/Markdown.vue
@@ -29,7 +29,7 @@ export default {
         .use(require('markdown-it-footnote'))
       let html = md.render(this.markdown)
 
-      html = this.useResponsiveImages(html)
+      html = this.useComputedImages(html)
       html = this.wrapTable(html)
       html = html.replace(/<table>/g, '<table class="table is-striped">')
 
@@ -37,25 +37,37 @@ export default {
     }
   },
   methods: {
-    useResponsiveImages(html) {
+    useComputedImages(html) {
       const images = html.match(/<img(.*?)>/g)
       if (images) {
         images.forEach((image) => {
-          // const generatedImage = require('~/assets')
-          const origImage = image
+          const imgSrc = image
             .match(/src="([^"]*)"/g)[0]
             .replace('src="', '')
             .replace('"', '')
-          let replace = `src="${origImage}"`
-          if (origImage.startsWith('/')) {
-            const generatedImage = require(`~/assets${origImage}`)
-            replace = `src="${generatedImage.src}" srcset="${generatedImage.srcSet}"`
+
+          let newImgSrc = `src="${imgSrc}"`
+
+          if (imgSrc.startsWith('/')) {
+            const computedImage = require(`~/assets${imgSrc}`)
+            newImgSrc = `src="${computedImage.src}" srcset="${computedImage.srcSet}"`
           }
 
-          const optiImage = image
+          const imgCaption = image
+            .match(/alt="([^"]*)"/g)[0]
+            .replace('alt="', '')
+            .replace('"', '')
+
+          const newImgTag = image
             .replace('>', '/>')
-            .replace(/src="([^"]*)"/g, replace)
-          html = html.replace(image, optiImage)
+            .replace(/src="([^"]*)"/g, newImgSrc)
+
+          const wrappedImg =
+            `<figure class="image">${newImgTag}` +
+            `<figcaption>${imgCaption}</figcaption>` +
+            `</figure>`
+
+          html = html.replace(image, wrappedImg)
         })
       }
       return html

--- a/components/Markdown.vue
+++ b/components/Markdown.vue
@@ -53,7 +53,6 @@ export default {
           }
 
           const optiImage = image
-            .replace('<img', '<opti-image')
             .replace('>', '/>')
             .replace(/src="([^"]*)"/g, replace)
           html = html.replace(image, optiImage)

--- a/components/SiteHero.vue
+++ b/components/SiteHero.vue
@@ -83,13 +83,6 @@ export default {
   border-top: 2px solid $primary;
   padding-top: 5px;
 }
-.opti-image {
-  opacity: 0;
-}
-.opti-image-loaded {
-  opacity: 0.12;
-  animation: blurIn 4.5s ease;
-}
 </style>
 <style lang="scss">
 .hero {
@@ -103,20 +96,10 @@ export default {
     width: 100%;
     height: 100%;
   }
-  .opti-image {
-    opacity: 0;
-  }
-  .opti-image-loaded {
-    opacity: 1;
-  }
 }
 .hero-theme-mist {
   .hero-bg-img {
     filter: grayscale(1);
-  }
-  .opti-image-loaded {
-    opacity: 0.12;
-    animation: blurInGrayscale 4.5s ease;
   }
 }
 .hero-theme-dark,

--- a/components/cards/GenericCard.vue
+++ b/components/cards/GenericCard.vue
@@ -3,7 +3,7 @@
     <div class="card-image">
       <component :is="link ? 'nuxt-link' : 'span'" :to="link">
         <figure :class="`image is-${imageRatioClass}`">
-          <opti-image
+          <img
             v-if="image"
             :src="responsiveImage.src"
             :srcset="responsiveImage.srcSet"
@@ -11,7 +11,6 @@
             :height="imageRatio[1]"
             :sizes="`(min-width: 768px) ${100 / $siteConfig.posts.perRow}vw`"
           />
-          <loading-spinner position="absolute" />
         </figure>
       </component>
     </div>
@@ -102,9 +101,6 @@ export default {
 }
 </style>
 <style lang="scss">
-.opti-image-loaded + .spinner-wrapper {
-  display: none;
-}
 .card img {
   transition: 0.8s ease-in-out all;
   &:hover {

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,6 +1,5 @@
 export default [
   '~/plugins/Globals',
-  '~/plugins/OptiImage',
   '~/plugins/Disqus',
   '~/plugins/EventBus',
   '~/plugins/Components'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12207,16 +12207,6 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
       "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
     },
-    "opti-image": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/opti-image/-/opti-image-0.10.0.tgz",
-      "integrity": "sha512-g0LnoYipn5YcABP3XPR0twcVLJ2uhdWqWzzFO77RWK+lqK2CakYQAI1dLnWYoSrN/UMww5CJ7NIbi93TnqXpTQ==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "vue": "^2.6.10",
-        "vue-runtime-helpers": "^1.0.1"
-      }
-    },
     "optimize-css-assets-webpack-plugin": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
@@ -17737,7 +17727,8 @@
     "vue": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
+      "dev": true
     },
     "vue-analytics": {
       "version": "5.17.0",
@@ -17831,11 +17822,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.6.tgz",
       "integrity": "sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA=="
-    },
-    "vue-runtime-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vue-runtime-helpers/-/vue-runtime-helpers-1.0.1.tgz",
-      "integrity": "sha512-yodqdAWt/QrUkb51jN2DS4dtF4vQWg5YejYdBAcHIOi6kBoGLRVEDz5NYGdh5IhzLrElgi+eKX1DQJmj3bCuJw=="
     },
     "vue-server-renderer": {
       "version": "2.6.11",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "nuxt": "^2.12.2",
     "nuxt-buefy": "^0.3.2",
     "nuxt-fontawesome": "^0.4.0",
-    "opti-image": "^0.10.0",
     "react": "^16.8.6",
     "showdown": "^1.9.1",
     "url-parse": "^1.4.7",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -23,7 +23,7 @@
             </div>
             <div class="column is-one-third">
               <figure class="image img-small">
-                <opti-image
+                <img
                   class="is-rounded"
                   :src="require('~/static/img/about-tuttiq.jpg').src"
                   :srcset="require('~/static/img/about-tuttiq.jpg').srcSet"
@@ -81,7 +81,7 @@
             </div>
             <div class="column">
               <figure class="image">
-                <opti-image
+                <img
                   :src="require('~/assets/uploads/mercari-build.jpg').src"
                   :srcset="require('~/assets/uploads/mercari-build.jpg').srcSet"
                 />
@@ -115,7 +115,7 @@
           <div class="columns is-desktop">
             <div class="column">
               <figure class="image">
-                <opti-image
+                <img
                   :src="require('~/assets/uploads/tuttiq_speaking.png').src"
                   :srcset="
                     require('~/assets/uploads/tuttiq_speaking.png').srcSet

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -13,7 +13,7 @@
                 What can I do for you?
               </p>
               <figure class="image">
-                <opti-image
+                <img
                   :src="require('~/static/img/about-tuttiq.jpg').src"
                   :srcset="require('~/static/img/about-tuttiq.jpg').srcSet"
                 />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,7 +31,7 @@
         <div class="content has-text-centered">
           <span class="title">Meet Tutti</span>
           <figure class="image profile">
-            <opti-image
+            <img
               class="is-rounded"
               :src="require('~/static/img/about-tuttiq.jpg').src"
               :srcset="require('~/static/img/about-tuttiq.jpg').srcSet"

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -37,7 +37,7 @@
             </div>
             <div class="column">
               <figure class="image">
-                <opti-image
+                <img
                   :src="require('~/assets/uploads/wwcode_tokyo.png').src"
                   :srcset="require('~/assets/uploads/wwcode_tokyo.png').srcSet"
                 />
@@ -129,7 +129,7 @@
             </div>
             <div class="column">
               <figure class="image">
-                <opti-image
+                <img
                   :src="require('~/assets/uploads/leaddev_banner.png').src"
                   :srcset="
                     require('~/assets/uploads/leaddev_banner.png').srcSet
@@ -222,7 +222,7 @@
             </div>
             <div class="column">
               <figure class="image">
-                <opti-image
+                <img
                   :src="require('~/static/banner.png').src"
                   :srcset="require('~/static/banner.png').srcSet"
                 />

--- a/plugins/OptiImage.js
+++ b/plugins/OptiImage.js
@@ -1,3 +1,0 @@
-import Vue from 'vue'
-import OptiImage from 'opti-image'
-Vue.use(OptiImage)


### PR DESCRIPTION
- Remove opti-image plugin and replace all images by simple `img` tags
- Wrap all markdown images in `<figure class="image">` and parse alt text as `<figcaption>`
